### PR TITLE
Introduce production IR Visitor, Constant Folding transform, and optimization pipeline; integrate into CLI

### DIFF
--- a/SomeCompiler.Cli/Program.cs
+++ b/SomeCompiler.Cli/Program.cs
@@ -45,6 +45,12 @@ Result<SomeCompiler.Generation.Intermediate.Model.IntermediateCodeProgram> Gener
     return Result.Success(ir);
 }
 
+Result<SomeCompiler.Generation.Intermediate.Model.IntermediateCodeProgram> OptimizeIR(SomeCompiler.Generation.Intermediate.Model.IntermediateCodeProgram ir)
+{
+    return SomeCompiler.Generation.Intermediate.Model.Transforms.DefaultOptimizationPipeline
+        .Apply(ir);
+}
+
 Result<SomeCompiler.Z80.Core.GeneratedProgram> GenerateAsm(SomeCompiler.Generation.Intermediate.Model.IntermediateCodeProgram ir)
 {
     var z80 = new SomeCompiler.Z80.Z80Generator();
@@ -70,7 +76,8 @@ Result
     .Tap(PrintSource)
     .Bind(Analyze)
     .Tap(result => PrintDiagnostics(result.Node.AllErrors))
-    .Bind(GenerateIR)
+.Bind(GenerateIR)
+    .Bind(OptimizeIR)
     .Tap(PrintIR)
     .Bind(GenerateAsm)
     .Tap(PrintAsm)

--- a/SomeCompiler.Generation.Intermediate/Model/Transforms/ConstantFoldingVisitor.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Transforms/ConstantFoldingVisitor.cs
@@ -1,0 +1,134 @@
+using CSharpFunctionalExtensions;
+using SomeCompiler.Generation.Intermediate.Model.Codes;
+using SomeCompiler.Generation.Intermediate.Model.Visitors;
+
+namespace SomeCompiler.Generation.Intermediate.Model.Transforms;
+
+using ModelCode = SomeCompiler.Generation.Intermediate.Model.Codes.Code;
+using Ref = CodeGeneration.Model.Classes.Reference;
+
+public class ConstantFoldingVisitor : IIntermediateTransform, SomeCompiler.Generation.Intermediate.Model.Visitors.IModelCodeVisitor<SomeCompiler.Generation.Intermediate.Model.Codes.Code>
+{
+    private readonly Dictionary<Ref, int> consts = new();
+
+public Result<IntermediateCodeProgram> Run(IntermediateCodeProgram input)
+    {
+        consts.Clear();
+        var output = new List<ModelCode>();
+        foreach (var code in input)
+        {
+            var transformed = code.Accept(this);
+            output.Add(transformed);
+        }
+        return Result.Success(new IntermediateCodeProgram(output));
+    }
+
+public ModelCode VisitAdd(SomeCompiler.Generation.Intermediate.Model.Codes.Add code)
+    {
+        if (TryGet(code.Left, out var l) && TryGet(code.Right, out var r))
+            return AssignConst(code.Target, l + r);
+        Invalidate(code.Target);
+        return code;
+    }
+
+public ModelCode VisitSubtract(SomeCompiler.Generation.Intermediate.Model.Codes.Subtract code)
+    {
+        if (TryGet(code.Left, out var l) && TryGet(code.Right, out var r))
+            return AssignConst(code.Target, l - r);
+        Invalidate(code.Target);
+        return code;
+    }
+
+public ModelCode VisitMultiply(SomeCompiler.Generation.Intermediate.Model.Codes.Multiply code)
+    {
+        if (TryGet(code.Left, out var l) && TryGet(code.Right, out var r))
+            return AssignConst(code.Target, l * r);
+        Invalidate(code.Target);
+        return code;
+    }
+
+public ModelCode VisitDivide(SomeCompiler.Generation.Intermediate.Model.Codes.Divide code)
+    {
+        if (TryGet(code.Left, out var l) && TryGet(code.Right, out var r) && r != 0)
+            return AssignConst(code.Target, l / r);
+        Invalidate(code.Target);
+        return code;
+    }
+
+public ModelCode VisitAnd(SomeCompiler.Generation.Intermediate.Model.Codes.And code)
+    {
+        if (TryGet(code.Left, out var l) && TryGet(code.Right, out var r))
+            return AssignConst(code.Target, l & r);
+        Invalidate(code.Target);
+        return code;
+    }
+
+public ModelCode VisitOr(SomeCompiler.Generation.Intermediate.Model.Codes.Or code)
+    {
+        if (TryGet(code.Left, out var l) && TryGet(code.Right, out var r))
+            return AssignConst(code.Target, l | r);
+        Invalidate(code.Target);
+        return code;
+    }
+
+public ModelCode VisitAssign(SomeCompiler.Generation.Intermediate.Model.Codes.Assign code)
+    {
+        if (TryGet(code.Source, out var v))
+        {
+            consts[code.Target] = v;
+return new SomeCompiler.Generation.Intermediate.Model.Codes.AssignConstant(code.Target, v);
+        }
+        Invalidate(code.Target);
+        return code;
+    }
+
+public ModelCode VisitAssignConstant(SomeCompiler.Generation.Intermediate.Model.Codes.AssignConstant code)
+    {
+        consts[code.Target] = code.Source;
+        return code;
+    }
+
+public ModelCode VisitAssignFromReturn(SomeCompiler.Generation.Intermediate.Model.Codes.AssignFromReturn code)
+    {
+        Invalidate(code.Target);
+        return code;
+    }
+
+public ModelCode VisitLabel(SomeCompiler.Generation.Intermediate.Model.Codes.Label code) => code;
+public ModelCode VisitLocalLabel(SomeCompiler.Generation.Intermediate.Model.Codes.LocalLabel code) => code;
+
+public ModelCode VisitBranchIfZero(SomeCompiler.Generation.Intermediate.Model.Codes.BranchIfZero code) => code;
+public ModelCode VisitBranchIfNotZero(SomeCompiler.Generation.Intermediate.Model.Codes.BranchIfNotZero code) => code;
+public ModelCode VisitJump(SomeCompiler.Generation.Intermediate.Model.Codes.Jump code) => code;
+
+public ModelCode VisitCall(SomeCompiler.Generation.Intermediate.Model.Codes.Call code)
+    {
+        // Be conservative: calls may mutate any reference (by convention, we could scope later).
+        consts.Clear();
+        return code;
+    }
+
+public ModelCode VisitReturn(SomeCompiler.Generation.Intermediate.Model.Codes.Return code) => code;
+public ModelCode VisitEmptyReturn(SomeCompiler.Generation.Intermediate.Model.Codes.EmptyReturn code) => code;
+public ModelCode VisitHalt(SomeCompiler.Generation.Intermediate.Model.Codes.Halt code) => code;
+public ModelCode VisitLoadHLImm(SomeCompiler.Generation.Intermediate.Model.Codes.LoadHLImm code) => code;
+public ModelCode VisitLoadHLRef(SomeCompiler.Generation.Intermediate.Model.Codes.LoadHLRef code) => code;
+public ModelCode VisitParam(SomeCompiler.Generation.Intermediate.Model.Codes.Param code) => code;
+public ModelCode VisitParamConst(SomeCompiler.Generation.Intermediate.Model.Codes.ParamConst code) => code;
+public ModelCode VisitCleanArgs(SomeCompiler.Generation.Intermediate.Model.Codes.CleanArgs code) => code;
+
+public SomeCompiler.Generation.Intermediate.Model.Codes.Code VisitDefault(SomeCompiler.Generation.Intermediate.Model.Codes.Code code) => code;
+
+
+private bool TryGet(Ref r, out int value)
+        => consts.TryGetValue(r, out value);
+
+    private void Invalidate(Ref r)
+    {
+        if (consts.ContainsKey(r))
+            consts.Remove(r);
+    }
+
+private static ModelCode AssignConst(Ref target, int v)
+        => new SomeCompiler.Generation.Intermediate.Model.Codes.AssignConstant(target, v);
+}

--- a/SomeCompiler.Generation.Intermediate/Model/Transforms/DefaultOptimizationPipeline.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Transforms/DefaultOptimizationPipeline.cs
@@ -1,0 +1,13 @@
+using CSharpFunctionalExtensions;
+
+namespace SomeCompiler.Generation.Intermediate.Model.Transforms;
+
+public static class DefaultOptimizationPipeline
+{
+    public static Result<IntermediateCodeProgram> Apply(IntermediateCodeProgram program)
+    {
+        // For now: single pass constant folding. Later we can chain more transforms.
+        var folding = new ConstantFoldingVisitor();
+        return folding.Run(program);
+    }
+}

--- a/SomeCompiler.Generation.Intermediate/Model/Transforms/IIntermediateTransform.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Transforms/IIntermediateTransform.cs
@@ -1,0 +1,8 @@
+using CSharpFunctionalExtensions;
+
+namespace SomeCompiler.Generation.Intermediate.Model.Transforms;
+
+public interface IIntermediateTransform
+{
+    Result<IntermediateCodeProgram> Run(IntermediateCodeProgram input);
+}

--- a/SomeCompiler.Generation.Intermediate/Model/Visitors/IModelCodeVisitor.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Visitors/IModelCodeVisitor.cs
@@ -1,0 +1,42 @@
+using SomeCompiler.Generation.Intermediate.Model.Codes;
+
+namespace SomeCompiler.Generation.Intermediate.Model.Visitors;
+
+public interface IModelCodeVisitor<out T>
+{
+    // Arithmetic and logic
+    T VisitAdd(SomeCompiler.Generation.Intermediate.Model.Codes.Add code);
+    T VisitSubtract(SomeCompiler.Generation.Intermediate.Model.Codes.Subtract code);
+    T VisitMultiply(SomeCompiler.Generation.Intermediate.Model.Codes.Multiply code);
+    T VisitDivide(SomeCompiler.Generation.Intermediate.Model.Codes.Divide code);
+    T VisitAnd(SomeCompiler.Generation.Intermediate.Model.Codes.And code);
+    T VisitOr(SomeCompiler.Generation.Intermediate.Model.Codes.Or code);
+
+    // Assignment and movement
+    T VisitAssign(SomeCompiler.Generation.Intermediate.Model.Codes.Assign code);
+    T VisitAssignConstant(SomeCompiler.Generation.Intermediate.Model.Codes.AssignConstant code);
+    T VisitAssignFromReturn(SomeCompiler.Generation.Intermediate.Model.Codes.AssignFromReturn code);
+
+    // Control flow and labels
+    T VisitLabel(SomeCompiler.Generation.Intermediate.Model.Codes.Label code);
+    T VisitLocalLabel(SomeCompiler.Generation.Intermediate.Model.Codes.LocalLabel code);
+    T VisitBranchIfZero(SomeCompiler.Generation.Intermediate.Model.Codes.BranchIfZero code);
+    T VisitBranchIfNotZero(SomeCompiler.Generation.Intermediate.Model.Codes.BranchIfNotZero code);
+    T VisitJump(SomeCompiler.Generation.Intermediate.Model.Codes.Jump code);
+
+    // Calls and returns
+    T VisitCall(SomeCompiler.Generation.Intermediate.Model.Codes.Call code);
+    T VisitReturn(SomeCompiler.Generation.Intermediate.Model.Codes.Return code);
+    T VisitEmptyReturn(SomeCompiler.Generation.Intermediate.Model.Codes.EmptyReturn code);
+
+    // Misc/target-specific helpers in current IR
+    T VisitHalt(SomeCompiler.Generation.Intermediate.Model.Codes.Halt code);
+    T VisitLoadHLImm(SomeCompiler.Generation.Intermediate.Model.Codes.LoadHLImm code);
+    T VisitLoadHLRef(SomeCompiler.Generation.Intermediate.Model.Codes.LoadHLRef code);
+    T VisitParam(SomeCompiler.Generation.Intermediate.Model.Codes.Param code);
+    T VisitParamConst(SomeCompiler.Generation.Intermediate.Model.Codes.ParamConst code);
+    T VisitCleanArgs(SomeCompiler.Generation.Intermediate.Model.Codes.CleanArgs code);
+
+    // Fallback for future codes not yet modeled explicitly
+    T VisitDefault(SomeCompiler.Generation.Intermediate.Model.Codes.Code code);
+}

--- a/SomeCompiler.Generation.Intermediate/Model/Visitors/ModelCodeVisitingExtensions.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Visitors/ModelCodeVisitingExtensions.cs
@@ -1,0 +1,35 @@
+using SomeCompiler.Generation.Intermediate.Model.Codes;
+
+namespace SomeCompiler.Generation.Intermediate.Model.Visitors;
+
+public static class ModelCodeVisitingExtensions
+{
+    public static T Accept<T>(this SomeCompiler.Generation.Intermediate.Model.Codes.Code code, IModelCodeVisitor<T> visitor)
+        => code switch
+        {
+            SomeCompiler.Generation.Intermediate.Model.Codes.Add x => visitor.VisitAdd(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Subtract x => visitor.VisitSubtract(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Multiply x => visitor.VisitMultiply(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Divide x => visitor.VisitDivide(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.And x => visitor.VisitAnd(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Or x => visitor.VisitOr(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Assign x => visitor.VisitAssign(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.AssignConstant x => visitor.VisitAssignConstant(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.AssignFromReturn x => visitor.VisitAssignFromReturn(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Label x => visitor.VisitLabel(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.LocalLabel x => visitor.VisitLocalLabel(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.BranchIfZero x => visitor.VisitBranchIfZero(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.BranchIfNotZero x => visitor.VisitBranchIfNotZero(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Jump x => visitor.VisitJump(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Call x => visitor.VisitCall(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Return x => visitor.VisitReturn(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.EmptyReturn x => visitor.VisitEmptyReturn(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Halt x => visitor.VisitHalt(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.LoadHLImm x => visitor.VisitLoadHLImm(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.LoadHLRef x => visitor.VisitLoadHLRef(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.Param x => visitor.VisitParam(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.ParamConst x => visitor.VisitParamConst(x),
+            SomeCompiler.Generation.Intermediate.Model.Codes.CleanArgs x => visitor.VisitCleanArgs(x),
+            _ => visitor.VisitDefault(code)
+        };
+}


### PR DESCRIPTION
This PR formalizes a production-grade Visitor pattern over the IR model and introduces a first optimization pass (constant folding). It also wires a default optimization pipeline into the CLI, enabling clean, testable and composable IR transformations aligned with functional practices (CSharpFunctionalExtensions).\n\nChanges\n- IR Visitor (Model)\n  - Add IModelCodeVisitor<T> to traverse IR nodes under SomeCompiler.Generation.Intermediate.Model.Codes.\n  - Add ModelCodeVisitingExtensions with an Accept extension method that dispatches via pattern matching (no need to modify each record).\n- Transform infrastructure\n  - Add IIntermediateTransform (Run: Result<IntermediateCodeProgram>) for pure, composable passes.\n- Constant folding\n  - Add ConstantFoldingVisitor: propagates and folds constants across Assign/AssignConstant, Add/Subtract/Multiply/Divide, And/Or. Conservatively clears state on Call. Returns a new IntermediateCodeProgram (no in-place mutation).\n- Pipeline\n  - Add DefaultOptimizationPipeline.Apply that currently chains constant folding (ready to extend with more passes).\n- CLI integration\n  - Apply optimization pipeline right after IR generation and before IR printing and ASM emission.\n\nFollow-ups\n- Add PrettyPrinterVisitor to standardize IR rendering and snapshot tests.\n- Implement CopyPropagationVisitor and DeadCodeEliminationVisitor.\n- Consider BranchFoldingVisitor and a LoweringVisitor for target-specific idioms.