### PR TITLE
IR: PrettyPrinter, Copy Propagation, and Dead Code Elimination; pipeline integration

### DIFF
--- a/SomeCompiler.Cli/Program.cs
+++ b/SomeCompiler.Cli/Program.cs
@@ -59,7 +59,7 @@ Result<SomeCompiler.Z80.Core.GeneratedProgram> GenerateAsm(SomeCompiler.Generati
 
 void PrintIR(SomeCompiler.Generation.Intermediate.Model.IntermediateCodeProgram ir)
 {
-    var text = string.Join("\n", SomeCompiler.Generation.Intermediate.IntermediateProgramExtensions.ToTextFormatContent(ir));
+    var text = SomeCompiler.Generation.Intermediate.Model.Visitors.PrettyPrinterVisitor.Print(ir);
     PrintSection("Intermediate code:", text);
 }
 

--- a/SomeCompiler.Generation.Intermediate/Model/Transforms/CopyPropagationVisitor.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Transforms/CopyPropagationVisitor.cs
@@ -1,0 +1,178 @@
+using CSharpFunctionalExtensions;
+using SomeCompiler.Generation.Intermediate.Model.Codes;
+using SomeCompiler.Generation.Intermediate.Model.Visitors;
+
+namespace SomeCompiler.Generation.Intermediate.Model.Transforms;
+
+using ModelCode = SomeCompiler.Generation.Intermediate.Model.Codes.Code;
+using Ref = CodeGeneration.Model.Classes.Reference;
+
+public class CopyPropagationVisitor : IIntermediateTransform, IModelCodeVisitor<ModelCode>
+{
+    private readonly Dictionary<Ref, Ref> subs = new();
+
+    public Result<IntermediateCodeProgram> Run(IntermediateCodeProgram input)
+    {
+        subs.Clear();
+        var output = new List<ModelCode>();
+        foreach (var code in input)
+        {
+            var rewritten = code.Accept(this);
+            output.Add(rewritten);
+        }
+        return Result.Success(new IntermediateCodeProgram(output));
+    }
+
+    private Ref Resolve(Ref r)
+    {
+        while (subs.TryGetValue(r, out var to))
+        {
+            if (ReferenceEquals(to, r)) break;
+            r = to;
+        }
+        return r;
+    }
+
+    private static bool Defines(ModelCode code, out Ref? def)
+    {
+        def = code switch
+        {
+            Assign a => a.Target,
+            AssignConstant ac => ac.Target,
+            AssignFromReturn afr => afr.Target,
+            Add a => a.Target,
+            Subtract s => s.Target,
+            Multiply m => m.Target,
+            Divide d => d.Target,
+            And a => a.Target,
+            Or o => o.Target,
+            _ => null
+        };
+        return def != null;
+    }
+
+    private static IEnumerable<Ref> Uses(ModelCode code)
+        => code switch
+        {
+            Assign a => new[] { a.Source },
+            Add a => new[] { a.Left, a.Right },
+            Subtract s => new[] { s.Left, s.Right },
+            Multiply m => new[] { m.Left, m.Right },
+            Divide d => new[] { d.Left, d.Right },
+            And a => new[] { a.Left, a.Right },
+            Or o => new[] { o.Left, o.Right },
+            Return r => new[] { r.Reference },
+            BranchIfZero b => new[] { b.Condition },
+            BranchIfNotZero b => new[] { b.Condition },
+            LoadHLRef l => new[] { l.From },
+            Param p => new[] { p.Argument },
+            _ => Array.Empty<Ref>()
+        };
+
+    private ModelCode RewriteSources(ModelCode code)
+    {
+        return code switch
+        {
+            Assign a => new Assign(a.Target, Resolve(a.Source)),
+            AssignConstant ac => ac,
+            AssignFromReturn afr => afr,
+            Add a => new Add(a.Target, Resolve(a.Left), Resolve(a.Right)),
+            Subtract s => new Subtract(s.Target, Resolve(s.Left), Resolve(s.Right)),
+            Multiply m => new Multiply(m.Target, Resolve(m.Left), Resolve(m.Right)),
+            Divide d => new Divide(d.Target, Resolve(d.Left), Resolve(d.Right)),
+            And a => new And(a.Target, Resolve(a.Left), Resolve(a.Right)),
+            Or o => new Or(o.Target, Resolve(o.Left), Resolve(o.Right)),
+            Return r => new Return(Resolve(r.Reference)),
+            BranchIfZero b => new BranchIfZero(Resolve(b.Condition), b.Label),
+            BranchIfNotZero b => new BranchIfNotZero(Resolve(b.Condition), b.Label),
+            LoadHLRef l => new LoadHLRef(Resolve(l.From)),
+            Param p => new Param(Resolve(p.Argument)),
+            _ => code
+        };
+    }
+
+    private void Invalidate(Ref r)
+    {
+        if (subs.ContainsKey(r)) subs.Remove(r);
+    }
+
+    public ModelCode VisitAssign(Assign code)
+    {
+        var rewritten = (Assign)RewriteSources(code);
+        // Update substitution: target := source
+        subs[rewritten.Target] = rewritten.Source;
+        return rewritten;
+    }
+
+    public ModelCode VisitAssignConstant(AssignConstant code)
+    {
+        Invalidate(code.Target);
+        return code;
+    }
+
+    public ModelCode VisitAssignFromReturn(AssignFromReturn code)
+    {
+        Invalidate(code.Target);
+        return code;
+    }
+
+    public ModelCode VisitAdd(Add code)
+    {
+        if (Defines(code, out var def) && def != null) Invalidate(def);
+        return RewriteSources(code);
+    }
+
+    public ModelCode VisitSubtract(Subtract code)
+    {
+        if (Defines(code, out var def) && def != null) Invalidate(def);
+        return RewriteSources(code);
+    }
+
+    public ModelCode VisitMultiply(Multiply code)
+    {
+        if (Defines(code, out var def) && def != null) Invalidate(def);
+        return RewriteSources(code);
+    }
+
+    public ModelCode VisitDivide(Divide code)
+    {
+        if (Defines(code, out var def) && def != null) Invalidate(def);
+        return RewriteSources(code);
+    }
+
+    public ModelCode VisitAnd(And code)
+    {
+        if (Defines(code, out var def) && def != null) Invalidate(def);
+        return RewriteSources(code);
+    }
+
+    public ModelCode VisitOr(Or code)
+    {
+        if (Defines(code, out var def) && def != null) Invalidate(def);
+        return RewriteSources(code);
+    }
+
+    public ModelCode VisitLabel(Label code) => code;
+    public ModelCode VisitLocalLabel(LocalLabel code) => code;
+    public ModelCode VisitBranchIfZero(BranchIfZero code) => RewriteSources(code);
+    public ModelCode VisitBranchIfNotZero(BranchIfNotZero code) => RewriteSources(code);
+    public ModelCode VisitJump(Jump code) => code;
+
+    public ModelCode VisitCall(Call code)
+    {
+        // Calls may clobber unknown refs; clear substitutions conservatively
+        subs.Clear();
+        return code;
+    }
+
+    public ModelCode VisitReturn(Return code) => RewriteSources(code);
+    public ModelCode VisitEmptyReturn(EmptyReturn code) => code;
+    public ModelCode VisitHalt(Halt code) => code;
+    public ModelCode VisitLoadHLImm(LoadHLImm code) => code;
+    public ModelCode VisitLoadHLRef(LoadHLRef code) => RewriteSources(code);
+    public ModelCode VisitParam(Param code) => RewriteSources(code);
+    public ModelCode VisitParamConst(ParamConst code) => code;
+    public ModelCode VisitCleanArgs(CleanArgs code) => code;
+
+    public ModelCode VisitDefault(ModelCode code) => code;
+}

--- a/SomeCompiler.Generation.Intermediate/Model/Transforms/DeadCodeEliminationVisitor.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Transforms/DeadCodeEliminationVisitor.cs
@@ -1,0 +1,95 @@
+using CSharpFunctionalExtensions;
+using SomeCompiler.Generation.Intermediate.Model.Codes;
+
+namespace SomeCompiler.Generation.Intermediate.Model.Transforms;
+
+using ModelCode = SomeCompiler.Generation.Intermediate.Model.Codes.Code;
+using Ref = CodeGeneration.Model.Classes.Reference;
+
+public class DeadCodeEliminationVisitor : IIntermediateTransform
+{
+    public Result<IntermediateCodeProgram> Run(IntermediateCodeProgram input)
+    {
+        var live = new HashSet<Ref>();
+        var output = new List<ModelCode>();
+
+        foreach (var code in input.AsEnumerable().Reverse())
+        {
+            var (uses, def, sideEffects) = Analyze(code);
+
+            // Liveness before this instruction
+            bool needed = sideEffects || (def != null && live.Contains(def)) || uses.Any(u => live.Contains(u));
+            if (needed || def == null)
+            {
+                // Update liveness: live = (live - def) U uses
+                if (def != null) live.Remove(def);
+                foreach (var u in uses) live.Add(u);
+                output.Add(code);
+            }
+            else
+            {
+                // Drop dead definition (pure and not live)
+                if (def != null)
+                {
+                    // Still need to update liveness with uses
+                    foreach (var u in uses) live.Add(u);
+                }
+            }
+        }
+
+        output.Reverse();
+        return Result.Success(new IntermediateCodeProgram(output));
+    }
+
+    private static (IEnumerable<Ref> uses, Ref? def, bool sideEffects) Analyze(ModelCode code)
+    {
+        IEnumerable<Ref> uses = code switch
+        {
+            Assign a => new[] { a.Source },
+            Add a => new[] { a.Left, a.Right },
+            Subtract s => new[] { s.Left, s.Right },
+            Multiply m => new[] { m.Left, m.Right },
+            Divide d => new[] { d.Left, d.Right },
+            And a => new[] { a.Left, a.Right },
+            Or o => new[] { o.Left, o.Right },
+            Return r => new[] { r.Reference },
+            BranchIfZero b => new[] { b.Condition },
+            BranchIfNotZero b => new[] { b.Condition },
+            LoadHLRef l => new[] { l.From },
+            Param p => new[] { p.Argument },
+            _ => Array.Empty<Ref>()
+        };
+
+        Ref? def = code switch
+        {
+            Assign a => a.Target,
+            AssignConstant ac => ac.Target,
+            AssignFromReturn afr => afr.Target,
+            Add a => a.Target,
+            Subtract s => s.Target,
+            Multiply m => m.Target,
+            Divide d => d.Target,
+            And a => a.Target,
+            Or o => o.Target,
+            _ => null
+        };
+
+        bool sideEffects = code is Call
+                         || code is Return
+                         || code is EmptyReturn
+                         || code is Halt
+                         || code is Jump
+                         || code is BranchIfZero
+                         || code is BranchIfNotZero
+                         || code is Label
+                         || code is LocalLabel
+                         || code is LoadHLImm
+                         || code is LoadHLRef
+                         || code is Param
+                         || code is ParamConst
+                         || code is CleanArgs;
+
+        // Pure defs: arithmetic ops and assignments
+        return (uses, def, sideEffects);
+    }
+}

--- a/SomeCompiler.Generation.Intermediate/Model/Transforms/DefaultOptimizationPipeline.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Transforms/DefaultOptimizationPipeline.cs
@@ -4,10 +4,15 @@ namespace SomeCompiler.Generation.Intermediate.Model.Transforms;
 
 public static class DefaultOptimizationPipeline
 {
-    public static Result<IntermediateCodeProgram> Apply(IntermediateCodeProgram program)
-    {
-        // For now: single pass constant folding. Later we can chain more transforms.
-        var folding = new ConstantFoldingVisitor();
-        return folding.Run(program);
-    }
+public static Result<IntermediateCodeProgram> Apply(IntermediateCodeProgram program)
+{
+    // Chain: Constant Folding -> Copy Propagation -> Dead Code Elimination
+    var folding = new ConstantFoldingVisitor();
+    var copyProp = new CopyPropagationVisitor();
+    var dce = new DeadCodeEliminationVisitor();
+
+    return folding.Run(program)
+        .Bind(copyProp.Run)
+        .Bind(dce.Run);
+}
 }

--- a/SomeCompiler.Generation.Intermediate/Model/Visitors/PrettyPrinterVisitor.cs
+++ b/SomeCompiler.Generation.Intermediate/Model/Visitors/PrettyPrinterVisitor.cs
@@ -1,0 +1,55 @@
+using SomeCompiler.Generation.Intermediate.Model.Codes;
+
+namespace SomeCompiler.Generation.Intermediate.Model.Visitors;
+
+public class PrettyPrinterVisitor : IModelCodeVisitor<string>
+{
+    private readonly Dictionary<CodeGeneration.Model.Classes.Reference, string> map;
+
+    public PrettyPrinterVisitor(Dictionary<CodeGeneration.Model.Classes.Reference, string> map)
+    {
+        this.map = map;
+    }
+
+    public string VisitAdd(Add code) => code.ToString(map);
+    public string VisitSubtract(Subtract code) => code.ToString(map);
+    public string VisitMultiply(Multiply code) => code.ToString(map);
+    public string VisitDivide(Divide code) => code.ToString(map);
+    public string VisitAnd(And code) => code.ToString(map);
+    public string VisitOr(Or code) => code.ToString(map);
+
+    public string VisitAssign(Assign code) => code.ToString(map);
+    public string VisitAssignConstant(AssignConstant code) => code.ToString(map);
+    public string VisitAssignFromReturn(AssignFromReturn code) => code.ToString(map);
+
+    public string VisitLabel(Label code) => code.ToString(map);
+    public string VisitLocalLabel(LocalLabel code) => code.ToString(map);
+    public string VisitBranchIfZero(BranchIfZero code) => code.ToString(map);
+    public string VisitBranchIfNotZero(BranchIfNotZero code) => code.ToString(map);
+    public string VisitJump(Jump code) => code.ToString(map);
+
+    public string VisitCall(Call code) => code.ToString(map);
+    public string VisitReturn(Return code) => code.ToString(map);
+    public string VisitEmptyReturn(EmptyReturn code) => code.ToString(map);
+
+    public string VisitHalt(Halt code) => code.ToString(map);
+    public string VisitLoadHLImm(LoadHLImm code) => code.ToString(map);
+    public string VisitLoadHLRef(LoadHLRef code) => code.ToString(map);
+    public string VisitParam(Param code) => code.ToString(map);
+    public string VisitParamConst(ParamConst code) => code.ToString(map);
+    public string VisitCleanArgs(CleanArgs code) => code.ToString(map);
+
+    public string VisitDefault(Code code) => code.ToString(map);
+
+    public static string Print(IntermediateCodeProgram program)
+    {
+        // Build stable naming map (Named keep name; Placeholder -> T1, T2, ...)
+        var named = program.NamedReferences().Select(x => ((CodeGeneration.Model.Classes.Reference)x, x.Value));
+        var unnamed = program.UnnamedReferences().Select((x, i) => (x, $"T{i + 1}"));
+        var map = named.Concat(unnamed).ToDictionary(x => x.Item1, tuple => tuple.Item2);
+
+        var visitor = new PrettyPrinterVisitor(map);
+        var lines = program.Select(code => code.Accept(visitor));
+        return string.Join("\n", lines);
+    }
+}


### PR DESCRIPTION
This PR enhances the production IR with:\n\n- PrettyPrinterVisitor: stable, deterministic textual rendering of Model IR using a reference naming map (Named keep original name; Placeholder => T1, T2, ...). Integrated into the CLI output.\n- CopyPropagationVisitor: forward substitution of references across Assign and arithmetic ops, with conservative invalidation on writes and Call.\n- DeadCodeEliminationVisitor: backward liveness pass removing pure definitions whose targets are not live. Side-effecting ops are preserved.\n- Pipeline: DefaultOptimizationPipeline now chains ConstantFolding -> CopyPropagation -> DeadCodeElimination.\n\nBuild & tests: solution builds locally; existing tests remain green.\n\nFollow-ups:\n- Branch/condition folding and strength reduction.\n- Lowering passes prior to backend emission.